### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -56,6 +56,8 @@ After checking out the source, run:
 This task will install any missing dependencies, run the tests, and generate the
 RDoc.
 
+Test on RapidAPI: https://rapidapi.com/package/BingSearch?utm_source=BingGitHub&utm_medium=button
+
 == LICENSE:
 
 (The MIT License)


### PR DESCRIPTION
I've added a link in your README to Bing's functions page in RapidAPI. I've done this for a few Bing SDKs to help those who are reading the READMEs, understand and test the API before use.